### PR TITLE
fix: ensure that `postcss-preset-env` and `cssnano` are last in plugin list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ function postcss8Module () {
       names = moveToFirst(names, 'postcss-url')
       names = moveToFirst(names, 'postcss-import')
       names = moveToLast(names, 'autoprefixer')
+      names = moveToLast(names, 'postcss-preset-env')
+      names = moveToLast(names, 'cssnano')
       return names
     }
   })


### PR DESCRIPTION
By default in Nuxt.js [`postcss-preset-env` and `cssnano` and moved to the end of the PostCSS plugin list](https://github.com/nuxt/nuxt.js/blob/2ec62617ced873fef97c73a6d7aa1271911ccfd5/packages/webpack/src/utils/postcss.js#L24-L26), but [`@nuxt/postcss8` overrides the `order` function](https://github.com/nuxt/postcss8/blob/main/src/index.ts#L26-L31), which can cause these plugins to appear in the middle of the list.

This pull request updates the `order` function to move `postcss-preset-env` and `cssnano` to the end of the plugin list, to match the default behaviour.

This will also fix the following issues with `@nuxtjs/tailwindcss`:

- https://github.com/nuxt-community/tailwindcss-module/issues/361
- https://github.com/nuxt-community/tailwindcss-module/issues/334

In both instances the final CSS is not minified because `cssnano` runs before `tailwindcss`.