### PR TITLE
fix: Nuxt3 version support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { name, version } from '../package.json'
 
 function postcss8Module () {
   const { nuxt } = this
-  const nuxtVersion = (nuxt.constructor.version || '0.0.0').split('-')[0]
+  const nuxtVersion = (nuxt.constructor.version || nuxt._version || '0.0.0').split('-')[0]
   const expectedVersion = '>=2.15.3'
   if (!satisfies(nuxtVersion, expectedVersion)) {
     throw new Error(`postcss@8 is not compatible with current version of nuxt (${nuxtVersion}). Expected: ${expectedVersion}`)


### PR DESCRIPTION
This fix is regarding error: **postcss@8 is not compatible with current version of nuxt** for nuxt3

The version nuxt3 object looks like:
```
{
  "_version": "3.0.0-xxxxx",
  "options": {
    "buildModules": [
      "@nuxt/postcss8",
      .......
```
so **nuxt._version** will return the right version